### PR TITLE
Serialise data-page writes across collections sharing one file

### DIFF
--- a/src/BLite.Core/Collections/DocumentCollection.cs
+++ b/src/BLite.Core/Collections/DocumentCollection.cs
@@ -67,8 +67,11 @@ public class DocumentCollection<TId, T> : IDocumentCollection<TId, T>, IDisposab
 
     public SchemaVersion? CurrentSchemaVersion { get; private set; }
 
-    // Concurrency control for write operations (B-Tree and Page modifications)
-    private readonly SemaphoreSlim _collectionLock = new(1, 1);
+    // Concurrency control for write operations (B-Tree and Page modifications).
+    // Obtained from the storage engine: single-file databases share one instance across all
+    // collections, because page placement depends on file-wide state. Never disposed here — the
+    // instance may be shared with other collections.
+    private readonly SemaphoreSlim _collectionLock;
     private int WriteLockTimeoutMs => _storage.LockTimeout.WriteTimeoutMs;
 
     private readonly int _maxDocumentSizeForSinglePage;
@@ -625,6 +628,7 @@ public class DocumentCollection<TId, T> : IDocumentCollection<TId, T>, IDisposab
         _transactionHolder = transactionHolder ?? throw new ArgumentNullException(nameof(transactionHolder));
         _mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
         _collectionName = collectionName ?? _mapper.CollectionName;
+        _collectionLock = _storage.CreateCollectionWriteLock();
 
         // Initialize secondary index manager first (loads metadata including Primary Root Page ID)
         _indexManager = new CollectionIndexManager<TId, T>(_storage, _mapper, _collectionName);

--- a/src/BLite.Core/Storage/StorageEngine.cs
+++ b/src/BLite.Core/Storage/StorageEngine.cs
@@ -83,6 +83,15 @@ public sealed partial class StorageEngine : IDisposable
     // null when MaxConcurrentWriters == 0 (admission control disabled).
     private readonly SemaphoreSlim? _writerGate;
 
+    // Serialises data-page writes across every collection backed by this engine's file.
+    // A DocumentCollection locks its own writes, but page placement depends on state shared by
+    // the whole file: the free-space index (FreeSpaceIndexProvider hands out one instance in
+    // single-file mode) and the page allocator. FindPageWithSpace and InsertIntoPage are two
+    // separate calls, so without a file-wide lock two collections can be handed the same page,
+    // and since a page is written back as a whole buffer the loser's slots are dropped.
+    // Null in collection-per-file mode, where nothing is shared and per-collection locks suffice.
+    private readonly SemaphoreSlim? _dataWriteLock;
+
     // Group commit writer infrastructure.
     private readonly Channel<PendingCommit> _commitChannel;
     private readonly CancellationTokenSource _writerCts = new();
@@ -106,6 +115,15 @@ public sealed partial class StorageEngine : IDisposable
     /// </summary>
     internal LockTimeout LockTimeout => _config.LockTimeout;
     internal bool UsesSeparateCollectionFiles => _collectionFiles != null;
+
+    /// <summary>
+    /// Returns the semaphore a <see cref="Collections.DocumentCollection{TId,T}"/> must hold for
+    /// write operations. In single-file mode every collection of this engine gets the same
+    /// instance, because they share the free-space index and the page allocator
+    /// (see <see cref="_dataWriteLock"/>). In collection-per-file mode each collection gets its
+    /// own, preserving write concurrency between collections.
+    /// </summary>
+    internal SemaphoreSlim CreateCollectionWriteLock() => _dataWriteLock ?? new SemaphoreSlim(1, 1);
 
     /// <summary>
     /// Multi-process WAL coordination sidecar; <c>null</c> when
@@ -199,6 +217,8 @@ public sealed partial class StorageEngine : IDisposable
                 ? new SemaphoreSlim(config.LockTimeout.MaxConcurrentWriters, config.LockTimeout.MaxConcurrentWriters)
                 : null;
 
+            _dataWriteLock = _collectionFiles == null ? new SemaphoreSlim(1, 1) : null;
+
             // Start the group commit writer.
             _commitChannel = Channel.CreateBounded<PendingCommit>(new BoundedChannelOptions(4096)
             {
@@ -266,6 +286,7 @@ public sealed partial class StorageEngine : IDisposable
         _nextTransactionId = 0;
 
         _writerGate = null; // No admission control needed for single-backend mode.
+        _dataWriteLock = new SemaphoreSlim(1, 1);
 
         _commitChannel = Channel.CreateBounded<PendingCommit>(new BoundedChannelOptions(4096)
         {

--- a/tests/BLite.Tests/CrossCollectionWriteRaceTests.cs
+++ b/tests/BLite.Tests/CrossCollectionWriteRaceTests.cs
@@ -1,0 +1,120 @@
+using BLite.Shared;
+
+namespace BLite.Tests
+{
+    /// <summary>
+    /// Regression coverage for concurrent writes to different collections of the same single-file
+    /// database. Each collection locks its own writes, but page placement depends on file-wide
+    /// state — the shared FreeSpaceIndex and the page allocator — and FindPageWithSpace and
+    /// InsertIntoPage are two separate calls. Without a file-wide write lock two collections are
+    /// handed the same page: the loser either fails the space check
+    /// ("Not enough space: need N, have M | PageId=...") or, when the check passes, writes over
+    /// slots another collection's primary index still points at.
+    /// </summary>
+    public class CrossCollectionWriteRaceTests : IDisposable
+    {
+        private static readonly TimeSpan Duration = TimeSpan.FromSeconds(5);
+
+        private readonly string _path;
+
+        public CrossCollectionWriteRaceTests()
+        {
+            _path = Path.Combine(Path.GetTempPath(), $"blite_xcoll_{Guid.NewGuid()}.db");
+        }
+
+        public void Dispose()
+        {
+            foreach (var suffix in new[] { "", ".wal" })
+            {
+                var file = _path + suffix;
+                if (File.Exists(file)) File.Delete(file);
+            }
+        }
+
+        [Fact]
+        public async Task Concurrent_Inserts_Into_Different_Collections_LoseNothing()
+        {
+            using var db = new TestDbContext(_path);
+            using var cts = new CancellationTokenSource(Duration);
+
+            var failures = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+            var writtenIds = new System.Collections.Concurrent.ConcurrentBag<string>();
+
+            var stringWriter = Run(async () =>
+            {
+                var i = 0;
+                while (!cts.IsCancellationRequested)
+                {
+                    var id = Guid.NewGuid().ToString();
+                    await db.StringEntities.InsertAsync(new StringEntity
+                    {
+                        Id = id,
+                        Value = new string('s', 200 + (i % 900)),
+                    });
+                    writtenIds.Add(id);
+                    i++;
+                }
+            });
+
+            var intWriter = Run(async () =>
+            {
+                // Ids start at 1: 0 is default(int) and is treated as "no id assigned".
+                var i = 1;
+                while (!cts.IsCancellationRequested)
+                {
+                    await db.IntEntities.InsertAsync(new IntEntity
+                    {
+                        Id = i,
+                        Name = new string('i', 200 + (i % 900)),
+                    });
+                    i++;
+                }
+            });
+
+            var userWriter = Run(async () =>
+            {
+                var i = 0;
+                while (!cts.IsCancellationRequested)
+                {
+                    await db.Users.InsertAsync(new User
+                    {
+                        Name = new string('u', 200 + (i % 900)),
+                        Age = i,
+                    });
+                    i++;
+                }
+            });
+
+            await Task.WhenAll(stringWriter, intWriter, userWriter);
+
+            Assert.True(
+                failures.IsEmpty,
+                $"{failures.Count} writer failure(s); first: {failures.FirstOrDefault()}");
+
+            // A page handed to two collections drops slots without reporting anything at write
+            // time, so every id written has to come back and every document has to be intact.
+            var seen = new HashSet<string>();
+            await foreach (var e in db.StringEntities.FindAllAsync())
+            {
+                Assert.StartsWith("s", e.Value);
+                seen.Add(e.Id);
+            }
+
+            var missing = writtenIds.Where(id => !seen.Contains(id)).ToList();
+            Assert.True(
+                missing.Count == 0,
+                $"{missing.Count} of {writtenIds.Count} inserted documents are not enumerable "
+                + $"(FindAllAsync returned {seen.Count}); first missing id: {missing.FirstOrDefault()}");
+
+            await foreach (var e in db.IntEntities.FindAllAsync()) Assert.StartsWith("i", e.Name);
+            await foreach (var e in db.Users.FindAllAsync()) Assert.StartsWith("u", e.Name);
+
+            Task Run(Func<Task> body) => Task.Run(async () =>
+            {
+                try { await body(); }
+                catch (OperationCanceledException) { }
+                catch (Exception ex) { failures.Add(ex); }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #135.

## Problem

`DocumentCollection` serialises its own writes with `_collectionLock`
(`DocumentCollection.cs:71`), but page placement depends on state shared by every collection in
the file:

- the `FreeSpaceIndex` — `FreeSpaceIndexProvider` hands out a single instance whenever
  `UsesSeparateCollectionFiles` is false (`FreeSpaceIndexProvider.cs:18-29`)
- the page allocator in `StorageEngine`

`FindPageWithSpace` and `InsertIntoPage` are two separate calls with no lock spanning both, so it
is a check-then-act race between collections:

```
collection A: FindPageWithSpace(535)  -> enters FSI gate, reads, exits, returns pageId 2739
                                      <-- collection B fills 2739 here -->
collection A: InsertIntoPage(2739, …) -> re-reads the page: not enough space
```

The thrown `InvalidOperationException` is the *lucky* outcome. When the losing writer still fits,
the write goes through and lands over slots another collection's primary index still points at —
and since `InsertIntoPage` reads, modifies and writes back the page as a whole buffer, the other
collection's documents are dropped with nothing reported at write time. The damage surfaces much
later, on an unrelated read, as a BSON parse failure on a document that was never written that
way. Nothing is persisted corrupt, which is what makes it look like an encoding bug.

`UpdateAsync` reaches the same path through `UpdateDataCore` when a document outgrows its slot and
is relocated, so updates are affected too.

## Fix

`StorageEngine` now owns the write lock and hands it to collections:

- **single-file mode** — every collection of the engine gets the *same* `SemaphoreSlim`, so the
  whole find-page → write-page sequence is serialised file-wide.
- **collection-per-file mode** (`CollectionDataDirectory` set) — nothing is shared, so each
  collection gets its own lock and write concurrency between collections is preserved.

`DocumentCollection._collectionLock` changes from a field initialiser to
`_storage.CreateCollectionWriteLock()`. Every existing acquisition site is unchanged, so the lock
scope (which already covers `InsertCore`/`UpdateCore`/`DeleteCore` *and* the auto-commit) is the
same — only its granularity changes. The collection never disposes it, since the instance may be
shared.

Two files, ~20 lines. No public API change.

### Cost

Writes to different collections of a single-file database no longer overlap. That is the price of
correctness here: the state they contend on is file-wide, so a per-collection lock cannot make
those writes safe. Databases that want write concurrency across collections can use the
collection-per-file layout, which this PR leaves untouched.

Alternatives considered and rejected:

- *Reserving space inside the FSI gate* — closes the check-then-act window on the free-space
  index, but not the page read-modify-write: two collections holding disjoint reservations on the
  same page would still clobber each other on write-back.
- *A `FreeSpaceIndex` per collection in single-file mode* — removes the sharing but costs page
  reuse across collections and leaves the shared page allocator unprotected.

## Test

`tests/BLite.Tests/CrossCollectionWriteRaceTests.cs` — three writers on three collections of one
`TestDbContext`, plain `InsertAsync`, single process, 5 seconds. Asserts no writer exception, then
that every inserted id is enumerable and every document intact.

Bisected on this machine (macOS arm64, .NET 10.0.6):

| | result |
|---|---|
| with the fix | 3/3 pass |
| fix reverted, test kept | 3/3 fail |

Sample failure without the fix:

```
2 writer failure(s); first: System.InvalidOperationException:
Not enough space: need 272, have 179 | PageId=2601 | SlotCount=21 | Start=192 | End=371 | FSI=281
```

Note `FSI=281` against the page header's real `AvailableFreeSpace` of 179: the shared free-space
index is describing a page another collection has already consumed.

## Full suite

`dotnet test tests/BLite.Tests` → **2323 passed, 3 failed, 4 skipped**.

The 3 failures are `MultiProcessWalSharedMemoryTests`
(`WriterLock_IsMutualExclusion_AcrossInstances`,
`BeginTransaction_Phase7_ReplaysCrossProcessCommits`,
`Phase7_ReplayDoesNotDuplicate_LocalCommits`). Verified pre-existing: the same three fail on the
same machine with this branch's `src/` changes stashed. They are the macOS `flock`/`FileStream`
issue tracked in #134 and do not show up on the `ubuntu-latest` release pipeline.

## One thing I could not explain

While iterating on the test I saw a single run where one `StringEntity` out of ~34,500 was
inserted but not returned by `FindAllAsync`. It did not reproduce in the following 9 runs (6 of
them with per-id tracking rather than counting), and a single-writer single-collection probe of
35,000 inserts lost nothing across 3 runs. I could not pin it down and it is a different failure
mode from the one this PR fixes — flagging it rather than leaving it unsaid.

## Performance

Measured on this branch vs the same tree with the two `src/` files reverted to `da9795a~1`.
Release build, macOS arm64, .NET 10.0.6, single-file database, default `PageFileConfig`.
First rep of each scenario discarded as warm-up; run-to-run spread inside each set is roughly
±10%, so only the concurrent-insert delta is above noise.

| scenario | baseline | with fix | delta |
|---|---|---|---|
| A — 1 collection, 1 writer, 20k inserts | ~14.5k ops/s | ~13.7k ops/s | within noise |
| B — 3 collections, 3 writers, 30k inserts | ~19.5k ops/s, **4–9 errors/run** | ~16.1k ops/s, **0 errors** | **≈ −17%** |
| C — `FindAllAsync` over 100k docs | ~317k docs/s | ~330k docs/s | within noise |

**A** is unchanged by construction: the lock scope and acquisition sites are identical, only the
instance differs.

**C** is unchanged by construction too: reads never take the write lock.

**B** is the real cost, and it is the point of the change — writes to different collections of one
file no longer overlap. Note the baseline column is flattered by its own bug: every run lost 4–9
inserts to `Not enough space`, and a failed insert aborts at `InsertIntoPage` without doing the
rest of the work, so the baseline is doing measurably less work per "operation".

Databases that need write concurrency across collections can use the collection-per-file layout
(`CollectionDataDirectory`), where each collection keeps its own lock — that path is unchanged.
