### PR TITLE
Preserve DateTimeOffset's offset across BSON round-trip

### DIFF
--- a/src/BLite.Bson/BsonSpanReader.cs
+++ b/src/BLite.Bson/BsonSpanReader.cs
@@ -209,6 +209,17 @@ public ref struct BsonSpanReader
         return value;
     }
 
+    /// <summary>Not a standalone BSON element type - used only for the offset-in-minutes trailer in <see cref="ReadDateTimeOffset(BsonType)"/>.</summary>
+    private short ReadInt16()
+    {
+        if (Remaining < 2)
+            throw new InvalidOperationException("Not enough bytes to read Int16");
+
+        var value = BinaryPrimitives.ReadInt16LittleEndian(_buffer.Slice(_position, 2));
+        _position += 2;
+        return value;
+    }
+
     public long ReadInt64()
     {
         if (Remaining < 8)
@@ -323,12 +334,36 @@ public ref struct BsonSpanReader
     }
 
     /// <summary>
-    /// Reads a BSON DateTime as DateTimeOffset (UTC milliseconds since Unix epoch)
+    /// Reads a legacy BSON DateTime field (8-byte UTC millisecond timestamp) as a DateTimeOffset.
+    /// There is no offset on the wire in this format, so the result always has Offset=0 - use
+    /// <see cref="ReadDateTimeOffset(BsonType)"/> when the wire type is known, so a value written
+    /// by <c>WriteDateTimeOffset</c> (tagged <see cref="BsonType.DateTimeOffset"/>) comes back with
+    /// its original offset instead.
     /// </summary>
     public DateTimeOffset ReadDateTimeOffset()
     {
         var milliseconds = ReadInt64();
         return DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+    }
+
+    /// <summary>
+    /// Reads a DateTimeOffset field, coercing a legacy <see cref="BsonType.DateTime"/> wire value
+    /// (8 bytes, no offset - always predates this type, see <see cref="BsonType.DateTimeOffset"/>)
+    /// the same way <see cref="ReadDateTimeOffset()"/> does, or decoding the full 10-byte
+    /// <see cref="BsonType.DateTimeOffset"/> format (UTC milliseconds + signed offset-in-minutes)
+    /// when the offset was actually preserved on write.
+    /// </summary>
+    public DateTimeOffset ReadDateTimeOffset(BsonType bsonType)
+    {
+        if (bsonType != BsonType.DateTimeOffset)
+        {
+            return ReadDateTimeOffset();
+        }
+
+        var milliseconds = ReadInt64();
+        var offsetMinutes = ReadInt16();
+        var instant = DateTimeOffset.FromUnixTimeMilliseconds(milliseconds);
+        return instant.ToOffset(TimeSpan.FromMinutes(offsetMinutes));
     }
 
     /// <summary>
@@ -432,6 +467,9 @@ public ref struct BsonSpanReader
             case BsonType.Int64:
             case BsonType.Timestamp:
                 _position += 8;
+                break;
+            case BsonType.DateTimeOffset:
+                _position += 10; // 8-byte UTC millisecond timestamp + 2-byte offset-in-minutes
                 break;
             case BsonType.Decimal128:
                 _position += 16;

--- a/src/BLite.Bson/BsonSpanWriter.cs
+++ b/src/BLite.Bson/BsonSpanWriter.cs
@@ -255,12 +255,22 @@ public ref struct BsonSpanWriter
         _position += 8;
     }
 
+    /// <summary>
+    /// Writes a UTC instant plus its original offset (10 bytes: 8-byte UTC millisecond timestamp,
+    /// same layout as <see cref="WriteDateTime"/>, followed by a 2-byte signed offset in minutes).
+    /// Tagged <see cref="BsonType.DateTimeOffset"/>, not <see cref="BsonType.DateTime"/>, so
+    /// <see cref="BsonSpanReader.SkipValue"/> and typed readers know an extra 2 bytes follow and
+    /// can reconstruct the original wall-clock value instead of always normalising to UTC.
+    /// </summary>
     public void WriteDateTimeOffset(string name, DateTimeOffset value)
     {
-        WriteElementHeader(BsonType.DateTime, name);
+        WriteElementHeader(BsonType.DateTimeOffset, name);
         var milliseconds = value.ToUnixTimeMilliseconds();
         BinaryPrimitives.WriteInt64LittleEndian(_buffer.Slice(_position, 8), milliseconds);
         _position += 8;
+        var offsetMinutes = (short)value.Offset.TotalMinutes;
+        BinaryPrimitives.WriteInt16LittleEndian(_buffer.Slice(_position, 2), offsetMinutes);
+        _position += 2;
     }
 
     public void WriteTimeSpan(string name, TimeSpan value)
@@ -448,12 +458,16 @@ public ref struct BsonSpanWriter
         _position += 8;
     }
 
+    /// <summary>Array counterpart of <see cref="WriteDateTimeOffset(string, DateTimeOffset)"/> - see its remarks.</summary>
     public void WriteArrayDateTimeOffset(int index, DateTimeOffset value)
     {
-        WriteArrayElementHeader(BsonType.DateTime, index);
+        WriteArrayElementHeader(BsonType.DateTimeOffset, index);
         var milliseconds = value.ToUnixTimeMilliseconds();
         BinaryPrimitives.WriteInt64LittleEndian(_buffer.Slice(_position, 8), milliseconds);
         _position += 8;
+        var offsetMinutes = (short)value.Offset.TotalMinutes;
+        BinaryPrimitives.WriteInt16LittleEndian(_buffer.Slice(_position, 2), offsetMinutes);
+        _position += 2;
     }
 
     public void WriteArrayTimeSpan(int index, TimeSpan value)

--- a/src/BLite.Bson/BsonType.cs
+++ b/src/BLite.Bson/BsonType.cs
@@ -25,6 +25,17 @@ public enum BsonType : byte
     Timestamp = 0x11,
     Int64 = 0x12,
     Decimal128 = 0x13,
+
+    /// <summary>
+    /// BLite extension, not part of the BSON spec (0x14 is unassigned there). Distinct from
+    /// <see cref="DateTime"/> because it carries a UTC-offset alongside the instant - see
+    /// <see cref="BsonValue.FromDateTimeOffset"/> / <c>BsonSpanWriter.WriteDateTimeOffset</c>.
+    /// A <see cref="DateTimeOffset"/> value written before this type existed is still tagged
+    /// <see cref="DateTime"/> on disk (offset already lost at write time, not recoverable) -
+    /// readers must keep handling that tag for <see cref="DateTimeOffset"/> fields too.
+    /// </summary>
+    DateTimeOffset = 0x14,
+
     MinKey = 0xFF,
     MaxKey = 0x7F
 }

--- a/src/BLite.Bson/BsonValue.cs
+++ b/src/BLite.Bson/BsonValue.cs
@@ -323,7 +323,12 @@ public readonly struct BsonValue : IEquatable<BsonValue>
             BsonType.String => FromString(reader.ReadString()),
             BsonType.Boolean => FromBoolean(reader.ReadBoolean()),
             BsonType.ObjectId => FromObjectId(reader.ReadObjectId()),
-            BsonType.DateTime => FromDateTimeOffset(reader.ReadDateTimeOffset()),
+            // Must stay tagged BsonType.DateTime, matching the wire tag just read - not
+            // FromDateTimeOffset, which now tags BsonType.DateTimeOffset. Using it here would flip
+            // the in-memory type for every plain DateTime field (and every legacy DateTimeOffset
+            // value still under the old tag), so a later WriteTo would silently re-emit it in the
+            // new 10-byte layout even though nothing about its offset was actually recovered.
+            BsonType.DateTime => FromDateTime(reader.ReadDateTime()),
             BsonType.DateTimeOffset => FromDateTimeOffset(reader.ReadDateTimeOffset(BsonType.DateTimeOffset)),
             BsonType.Null => Null,
             BsonType.Binary => FromBinary(reader.ReadBinary(out _).ToArray()),

--- a/src/BLite.Bson/BsonValue.cs
+++ b/src/BLite.Bson/BsonValue.cs
@@ -43,7 +43,15 @@ public readonly struct BsonValue : IEquatable<BsonValue>
     public static BsonValue FromBoolean(bool value) => new(BsonType.Boolean, value ? 1 : 0);
     public static BsonValue FromObjectId(ObjectId value) => new(BsonType.ObjectId, refValue: value);
     public static BsonValue FromDateTime(DateTime value) => new(BsonType.DateTime, BitConverter.Int64BitsToDouble(new DateTimeOffset(value.ToUniversalTime()).ToUnixTimeMilliseconds()));
-    public static BsonValue FromDateTimeOffset(DateTimeOffset value) => new(BsonType.DateTime, BitConverter.Int64BitsToDouble(value.ToUnixTimeMilliseconds()));
+
+    /// <summary>
+    /// Tagged <see cref="BsonType.DateTimeOffset"/>, not <see cref="BsonType.DateTime"/>, so the
+    /// offset survives a round-trip through <see cref="WriteTo"/>/<see cref="ReadFrom"/> instead of
+    /// being silently normalised to UTC. The offset itself rides in <c>_refValue</c> (boxed
+    /// <see cref="short"/> minutes) since <c>_numericValue</c> already holds the packed instant.
+    /// </summary>
+    public static BsonValue FromDateTimeOffset(DateTimeOffset value) =>
+        new(BsonType.DateTimeOffset, BitConverter.Int64BitsToDouble(value.ToUnixTimeMilliseconds()), (short)value.Offset.TotalMinutes);
     public static BsonValue FromGuid(Guid value) => new(BsonType.String, refValue: value.ToString());
     public static BsonValue FromBinary(byte[] value) => new(BsonType.Binary, refValue: value ?? throw new ArgumentNullException(nameof(value)));
     public static BsonValue FromDocument(BsonDocument value) => new(BsonType.Document, refValue: value ?? throw new ArgumentNullException(nameof(value)));
@@ -110,13 +118,29 @@ public readonly struct BsonValue : IEquatable<BsonValue>
         ? oid
         : throw new InvalidOperationException($"BsonValue is {_type}, not ObjectId");
 
-    public DateTime AsDateTime => _type == BsonType.DateTime
-        ? DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue)).UtcDateTime
-        : throw new InvalidOperationException($"BsonValue is {_type}, not DateTime");
+    public DateTime AsDateTime => _type switch
+    {
+        BsonType.DateTime or BsonType.DateTimeOffset =>
+            DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue)).UtcDateTime,
+        _ => throw new InvalidOperationException($"BsonValue is {_type}, not DateTime")
+    };
 
-    public DateTimeOffset AsDateTimeOffset => _type == BsonType.DateTime
-        ? DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue))
-        : throw new InvalidOperationException($"BsonValue is {_type}, not DateTime");
+    /// <summary>
+    /// For <see cref="BsonType.DateTime"/> (a value written before offsets were tracked, or a plain
+    /// <see cref="DateTime"/> field) the offset is unknown and comes back as 0 (UTC). For
+    /// <see cref="BsonType.DateTimeOffset"/> the original offset (boxed in <c>_refValue</c>) is
+    /// restored via <see cref="DateTimeOffset.ToOffset"/>, which re-expresses the same instant -
+    /// it does not shift it.
+    /// </summary>
+    public DateTimeOffset AsDateTimeOffset => _type switch
+    {
+        BsonType.DateTimeOffset =>
+            DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue))
+                .ToOffset(TimeSpan.FromMinutes((short)_refValue!)),
+        BsonType.DateTime =>
+            DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue)),
+        _ => throw new InvalidOperationException($"BsonValue is {_type}, not DateTime")
+    };
 
     public byte[] AsBinary => _type == BsonType.Binary && _refValue is byte[] b
         ? b
@@ -149,6 +173,7 @@ public readonly struct BsonValue : IEquatable<BsonValue>
     public bool IsDouble => Type == BsonType.Double;
     public bool IsBoolean => Type == BsonType.Boolean;
     public bool IsDateTime => Type == BsonType.DateTime;
+    public bool IsDateTimeOffset => Type == BsonType.DateTimeOffset;
     public bool IsDecimal => Type == BsonType.Decimal128;
     public bool IsBinary => Type == BsonType.Binary;
     public bool IsObjectId => Type == BsonType.ObjectId;
@@ -195,6 +220,9 @@ public readonly struct BsonValue : IEquatable<BsonValue>
             case BsonType.DateTime:
                 var dt = DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue)).UtcDateTime;
                 writer.WriteDateTime(fieldName, dt);
+                break;
+            case BsonType.DateTimeOffset:
+                writer.WriteDateTimeOffset(fieldName, AsDateTimeOffset);
                 break;
             case BsonType.Binary:
                 writer.WriteBinary(fieldName, (byte[])_refValue!);
@@ -256,6 +284,9 @@ public readonly struct BsonValue : IEquatable<BsonValue>
             case BsonType.DateTime:
                 writer.WriteArrayDateTime(index, DateTimeOffset.FromUnixTimeMilliseconds(BitConverter.DoubleToInt64Bits(_numericValue)).UtcDateTime);
                 break;
+            case BsonType.DateTimeOffset:
+                writer.WriteArrayDateTimeOffset(index, AsDateTimeOffset);
+                break;
             case BsonType.Null:
                 writer.WriteArrayNull(index);
                 break;
@@ -293,6 +324,7 @@ public readonly struct BsonValue : IEquatable<BsonValue>
             BsonType.Boolean => FromBoolean(reader.ReadBoolean()),
             BsonType.ObjectId => FromObjectId(reader.ReadObjectId()),
             BsonType.DateTime => FromDateTimeOffset(reader.ReadDateTimeOffset()),
+            BsonType.DateTimeOffset => FromDateTimeOffset(reader.ReadDateTimeOffset(BsonType.DateTimeOffset)),
             BsonType.Null => Null,
             BsonType.Binary => FromBinary(reader.ReadBinary(out _).ToArray()),
             BsonType.Array => ReadArray(ref reader),
@@ -335,6 +367,11 @@ public readonly struct BsonValue : IEquatable<BsonValue>
         {
             BsonType.Int32 or BsonType.Int64 or BsonType.Double or BsonType.Boolean or BsonType.DateTime
                 => _numericValue == other._numericValue,
+            // Unlike DateTimeOffset.Equals (instant-only), the offset is treated as significant here:
+            // it's the whole reason this type exists, so two values landing on the same instant but
+            // written with a different offset are NOT the same BsonValue. Keeps this consistent with
+            // GetHashCode, which already combines both _numericValue and _refValue (the boxed offset).
+            BsonType.DateTimeOffset => _numericValue == other._numericValue && (short)_refValue! == (short)other._refValue!,
             BsonType.String => string.Equals((string?)_refValue, (string?)other._refValue, StringComparison.Ordinal),
             BsonType.ObjectId => Equals(_refValue, other._refValue),
             BsonType.Null => true,
@@ -361,6 +398,7 @@ public readonly struct BsonValue : IEquatable<BsonValue>
             BsonType.Boolean => (_numericValue != 0).ToString(),
             BsonType.ObjectId => _refValue?.ToString() ?? "(null)",
             BsonType.DateTime => AsDateTime.ToString("O"),
+            BsonType.DateTimeOffset => AsDateTimeOffset.ToString("O"),
             BsonType.Null => "null",
             _ => $"({_type})"
         };

--- a/src/BLite.Core/Collections/BsonSchemaGenerator.cs
+++ b/src/BLite.Core/Collections/BsonSchemaGenerator.cs
@@ -115,7 +115,8 @@ public static class BsonSchemaGenerator
         if (type == typeof(bool)) return (BsonType.Boolean, null, null);
         if (type == typeof(double)) return (BsonType.Double, null, null);
         if (type == typeof(decimal)) return (BsonType.Decimal128, null, null);
-        if (type == typeof(DateTime) || type == typeof(DateTimeOffset)) return (BsonType.DateTime, null, null);
+        if (type == typeof(DateTime)) return (BsonType.DateTime, null, null);
+        if (type == typeof(DateTimeOffset)) return (BsonType.DateTimeOffset, null, null);
         if (type == typeof(Guid)) return (BsonType.Binary, null, null); // Guid is usually Binary subtype
         if (type == typeof(byte[])) return (BsonType.Binary, null, null);
 

--- a/src/BLite.Core/Collections/DocumentCollection.cs
+++ b/src/BLite.Core/Collections/DocumentCollection.cs
@@ -408,7 +408,7 @@ public class DocumentCollection<TId, T> : IDocumentCollection<TId, T>, IDisposab
                 var value = BsonValue.ReadFrom(ref reader, seekType);
                 return value.Type switch
                 {
-                    BsonType.DateTime => value.AsDateTime.Ticks,
+                    BsonType.DateTime or BsonType.DateTimeOffset => value.AsDateTime.Ticks,
                     BsonType.Int64    => value.AsInt64,
                     _                 => 0
                 };
@@ -429,7 +429,7 @@ public class DocumentCollection<TId, T> : IDocumentCollection<TId, T>, IDisposab
                 var val = BsonValue.ReadFrom(ref reader, type);
                 return val.Type switch
                 {
-                    BsonType.DateTime => val.AsDateTime.Ticks,
+                    BsonType.DateTime or BsonType.DateTimeOffset => val.AsDateTime.Ticks,
                     BsonType.Int64    => val.AsInt64,
                     _                 => 0
                 };

--- a/src/BLite.Core/DynamicCollection.cs
+++ b/src/BLite.Core/DynamicCollection.cs
@@ -423,7 +423,7 @@ public sealed class DynamicCollection : IDisposable
                 {
                     ticks = tsVal.Type switch
                     {
-                        BsonType.DateTime => tsVal.AsDateTime.Ticks,
+                        BsonType.DateTime or BsonType.DateTimeOffset => tsVal.AsDateTime.Ticks,
                         BsonType.Int64    => tsVal.AsInt64,
                         _                 => 0
                     };
@@ -2001,8 +2001,10 @@ public sealed class DynamicCollection : IDisposable
             BsonType.ObjectId => new IndexKey(value.AsObjectId),
             BsonType.Double   => new IndexKey(BitConverter.GetBytes(value.AsDouble)),
             // DateTime is stored as BitConverter.Int64BitsToDouble(unixMs); key on the raw long
-            // to get the same ordering used by ToIndexObject in BlqlFilter.
-            BsonType.DateTime => new IndexKey(value.AsDateTimeOffset.ToUnixTimeMilliseconds()),
+            // to get the same ordering used by ToIndexObject in BlqlFilter. Deliberately keyed by
+            // instant, not offset, for DateTimeOffset too - the offset must not perturb range-scan
+            // ordering, only how the value is displayed once read back.
+            BsonType.DateTime or BsonType.DateTimeOffset => new IndexKey(value.AsDateTimeOffset.ToUnixTimeMilliseconds()),
             _ => null // Can't index this type as BTree key
         };
     }

--- a/src/BLite.Core/Query/Blql/BlqlFilter.cs
+++ b/src/BLite.Core/Query/Blql/BlqlFilter.cs
@@ -384,7 +384,8 @@ public abstract class BlqlFilter
             BsonType.ObjectId => v.AsObjectId,
             // DateTime is stored as BitConverter.Int64BitsToDouble(unixMs); extract as long so
             // CreateIndexKeyFromObject can create a comparable IndexKey(long) for BTree range scans.
-            BsonType.DateTime => v.AsDateTimeOffset.ToUnixTimeMilliseconds(),
+            // Keyed by instant for DateTimeOffset too, matching DynamicCollection.ToIndexObject.
+            BsonType.DateTime or BsonType.DateTimeOffset => v.AsDateTimeOffset.ToUnixTimeMilliseconds(),
             _                 => null
         };
     }

--- a/src/BLite.Core/Query/Blql/BsonValueComparer.cs
+++ b/src/BLite.Core/Query/Blql/BsonValueComparer.cs
@@ -26,6 +26,14 @@ internal static class BsonValueComparer
         if (IsNumeric(a.Type) && IsNumeric(b.Type))
             return ToDouble(a).CompareTo(ToDouble(b));
 
+        // DateTime/DateTimeOffset: compare by instant across the two tags too, same as the numeric
+        // family above. A collection can hold both during the transition after upgrading BLite - a
+        // DateTimeOffset value written before this type existed stays tagged DateTime forever - so
+        // this must not fall through to TypeOrder below, which would sort DateTimeOffset-tagged rows
+        // as unrelated to DateTime-tagged ones instead of interleaving them by actual time.
+        if (IsDateLike(a.Type) && IsDateLike(b.Type))
+            return a.AsDateTimeOffset.CompareTo(b.AsDateTimeOffset);
+
         // Same type comparisons
         if (a.Type == b.Type)
         {
@@ -33,7 +41,7 @@ internal static class BsonValueComparer
             {
                 BsonType.String    => string.Compare(a.AsString, b.AsString, StringComparison.Ordinal),
                 BsonType.Boolean   => a.AsBoolean.CompareTo(b.AsBoolean),
-                BsonType.DateTime  => a.AsDateTimeOffset.CompareTo(b.AsDateTimeOffset),
+                BsonType.DateTime or BsonType.DateTimeOffset => a.AsDateTimeOffset.CompareTo(b.AsDateTimeOffset),
                 BsonType.ObjectId  => CompareObjectIds(a.AsObjectId, b.AsObjectId),
                 BsonType.Binary    => CompareBytes(a.AsBinary, b.AsBinary),
                 _                  => 0
@@ -46,6 +54,9 @@ internal static class BsonValueComparer
 
     private static bool IsNumeric(BsonType t) =>
         t is BsonType.Int32 or BsonType.Int64 or BsonType.Double or BsonType.Decimal128;
+
+    private static bool IsDateLike(BsonType t) =>
+        t is BsonType.DateTime or BsonType.DateTimeOffset;
 
     private static double ToDouble(BsonValue v) => v.Type switch
     {
@@ -67,6 +78,7 @@ internal static class BsonValueComparer
         BsonType.String    => 3,
         BsonType.ObjectId  => 4,
         BsonType.DateTime  => 5,
+        BsonType.DateTimeOffset => 5,
         BsonType.Binary    => 6,
         BsonType.Document  => 7,
         BsonType.Array     => 8,

--- a/src/BLite.Core/Query/BsonExpressionEvaluator.cs
+++ b/src/BLite.Core/Query/BsonExpressionEvaluator.cs
@@ -596,6 +596,7 @@ internal static class BsonExpressionEvaluator
                     BsonType.Boolean => reader.ReadBoolean(),
                     BsonType.ObjectId => reader.ReadObjectId(),
                     BsonType.DateTime => reader.ReadDateTime(),
+                    BsonType.DateTimeOffset => reader.ReadDateTimeOffset(BsonType.DateTimeOffset),
                     BsonType.Null    => null,
                     _                => null
                 };
@@ -652,6 +653,7 @@ internal static class BsonExpressionEvaluator
                     BsonType.Boolean => reader.ReadBoolean(),
                     BsonType.ObjectId => reader.ReadObjectId(),
                     BsonType.DateTime => reader.ReadDateTime(),
+                    BsonType.DateTimeOffset => reader.ReadDateTimeOffset(BsonType.DateTimeOffset),
                     BsonType.Null    => null,
                     _                => null
                 };
@@ -1087,9 +1089,14 @@ internal static class BsonExpressionEvaluator
                 };
             }
         }
-        else if (type == BsonType.DateTime)
+        else if (type == BsonType.DateTime || type == BsonType.DateTimeOffset)
         {
-            var val = reader.ReadDateTime();
+            // Both tags land here: the comparisons below normalise everything to UTC ticks, so the
+            // offset (only relevant to how a DateTimeOffset value is displayed, not compared) doesn't
+            // need special handling once decoded - only the read itself must pick the matching layout.
+            var val = type == BsonType.DateTimeOffset
+                ? reader.ReadDateTimeOffset(BsonType.DateTimeOffset).UtcDateTime
+                : reader.ReadDateTime();
             if (target is DateTime targetDt)
             {
                 // Normalise both sides to UTC ticks for a reliable comparison.

--- a/src/BLite.Core/Query/BsonProjectionCompiler.cs
+++ b/src/BLite.Core/Query/BsonProjectionCompiler.cs
@@ -147,6 +147,9 @@ internal static class BsonProjectionCompiler
                             BsonType.ObjectId   => reader.ReadObjectId(),
                             BsonType.Boolean    => reader.ReadBoolean(),
                             BsonType.DateTime   => reader.ReadDateTime(),
+                            // Own case, not folded into DateTime above: the wire layouts differ (10
+                            // bytes vs 8), reading the wrong one desyncs every field read after it.
+                            BsonType.DateTimeOffset => (object?)reader.ReadDateTimeOffset(BsonType.DateTimeOffset),
                             BsonType.Int32      => reader.ReadInt32(),
                             BsonType.Int64      => reader.ReadInt64(),
                             BsonType.Decimal128 => reader.ReadDecimal128(),
@@ -178,6 +181,7 @@ internal static class BsonProjectionCompiler
                             case BsonType.ObjectId:  values[idx] = reader.ReadObjectId();  break;
                             case BsonType.Boolean:   values[idx] = reader.ReadBoolean();   break;
                             case BsonType.DateTime:  values[idx] = reader.ReadDateTime();  break;
+                            case BsonType.DateTimeOffset: values[idx] = reader.ReadDateTimeOffset(BsonType.DateTimeOffset); break;
                             case BsonType.Int32:     values[idx] = reader.ReadInt32();     break;
                             case BsonType.Int64:     values[idx] = reader.ReadInt64();     break;
                             case BsonType.Decimal128: values[idx] = reader.ReadDecimal128(); break;

--- a/src/BLite.Core/Storage/StorageEngine.Collections.cs
+++ b/src/BLite.Core/Storage/StorageEngine.Collections.cs
@@ -67,6 +67,7 @@ public class VectorSourceConfig
         BsonType.Array => string.Join(" ", value.AsArray.Select(ValueToString)),
         BsonType.ObjectId => value.AsObjectId.ToString(),
         BsonType.DateTime => value.AsDateTime.ToString("O"),
+        BsonType.DateTimeOffset => value.AsDateTimeOffset.ToString("O"),
         _ => null
     } ?? string.Empty;
 }

--- a/src/BLite.Core/Storage/StorageEngine.TimeSeries.cs
+++ b/src/BLite.Core/Storage/StorageEngine.TimeSeries.cs
@@ -23,7 +23,7 @@ public sealed partial class StorageEngine
         long timestamp = 0;
         if (meta.TtlFieldName != null && document.TryGetValue(meta.TtlFieldName, out var val))
         {
-            if (val.Type == BsonType.DateTime)
+            if (val.Type == BsonType.DateTime || val.Type == BsonType.DateTimeOffset)
                 timestamp = val.AsDateTime.Ticks;
             else if (val.Type == BsonType.Int64)
                 timestamp = val.AsInt64;

--- a/src/BLite.Core/Text/TextNormalizer.cs
+++ b/src/BLite.Core/Text/TextNormalizer.cs
@@ -110,6 +110,7 @@ public static class TextNormalizer
         BsonType.Array    => string.Join(" ", value.AsArray.Select(BsonValueToString)),
         BsonType.ObjectId => value.AsObjectId.ToString(),
         BsonType.DateTime => value.AsDateTime.ToString("O"),
+        BsonType.DateTimeOffset => value.AsDateTimeOffset.ToString("O"),
         _                 => string.Empty
     };
 }

--- a/src/BLite.SourceGenerators/CodeGenerator.cs
+++ b/src/BLite.SourceGenerators/CodeGenerator.cs
@@ -1173,7 +1173,12 @@ namespace BLite.SourceGenerators
         }
 
         private static bool IsCoercedReadMethod(string? readMethod)
-            => readMethod is "ReadInt32Coerced" or "ReadInt64Coerced" or "ReadDoubleCoerced";
+            // ReadDateTimeOffset(BsonType) isn't "coerced" in the numeric-widening sense of the others,
+            // but needs the wire type for the same reason: a DateTimeOffset property predating this type
+            // may still be stored under the legacy BsonType.DateTime tag (offset already lost at write
+            // time, not recoverable) and must decode with that tag's 8-byte layout instead of the new
+            // 10-byte one - see BsonType.DateTimeOffset.
+            => readMethod is "ReadInt32Coerced" or "ReadInt64Coerced" or "ReadDoubleCoerced" or "ReadDateTimeOffset";
 
         private static bool IsValueType(string typeName)
         {

--- a/tests/BLite.Tests/BsonSpanReaderWriterTests.cs
+++ b/tests/BLite.Tests/BsonSpanReaderWriterTests.cs
@@ -221,6 +221,47 @@ public class BsonSpanReaderWriterTests
     }
 
     [Fact]
+    public void BsonValue_ReadFrom_LegacyDateTimeTag_StaysTaggedDateTime()
+    {
+        // Regression for a review finding on the DateTimeOffset fix: BsonValue.ReadFrom must not
+        // reuse FromDateTimeOffset (now tagged BsonType.DateTimeOffset) to decode a wire-level plain
+        // BsonType.DateTime value - doing so would flip the in-memory type for every DateTime field
+        // and cause a later WriteTo to silently upgrade it to the new 10-byte layout on disk, even
+        // though nothing about an offset was actually recovered.
+        Span<byte> buffer = stackalloc byte[256];
+        var writer = new BsonSpanWriter(buffer, _keyMap);
+
+        var legacyUtc = new DateTime(2026, 6, 15, 18, 0, 0, DateTimeKind.Utc);
+
+        var sizePos = writer.BeginDocument();
+        writer.WriteDateTime("timestamp", legacyUtc);
+        writer.EndDocument(sizePos);
+
+        var documentBytes = buffer[..writer.Position];
+        var reader = new BsonSpanReader(documentBytes, _keys);
+
+        reader.ReadDocumentSize();
+        var type = reader.ReadBsonType();
+        reader.ReadElementHeader();
+
+        var value = BsonValue.ReadFrom(ref reader, type);
+
+        Assert.Equal(BsonType.DateTime, value.Type);
+        Assert.False(value.IsDateTimeOffset);
+
+        // Writing it back must reproduce the original 8-byte BsonType.DateTime wire format, not
+        // silently upgrade to the new 10-byte BsonType.DateTimeOffset layout.
+        Span<byte> rewriteBuffer = stackalloc byte[256];
+        var rewriter = new BsonSpanWriter(rewriteBuffer, _keyMap);
+        var rewriteSizePos = rewriter.BeginDocument();
+        value.WriteTo(ref rewriter, "timestamp");
+        rewriter.EndDocument(rewriteSizePos);
+
+        var rewrittenBytes = rewriteBuffer[..rewriter.Position];
+        Assert.True(documentBytes.SequenceEqual(rewrittenBytes));
+    }
+
+    [Fact]
     public void WriteAndRead_NumericTypes()
     {
         Span<byte> buffer = stackalloc byte[256];

--- a/tests/BLite.Tests/BsonSpanReaderWriterTests.cs
+++ b/tests/BLite.Tests/BsonSpanReaderWriterTests.cs
@@ -155,6 +155,72 @@ public class BsonSpanReaderWriterTests
     }
 
     [Fact]
+    public void WriteAndRead_DateTimeOffset_PreservesOffset()
+    {
+        Span<byte> buffer = stackalloc byte[256];
+        var writer = new BsonSpanWriter(buffer, _keyMap);
+
+        // A non-UTC offset (e.g. CEST, UTC+2): the instant this represents is 18:00 UTC, and the
+        // wall-clock value callers expect back is 20:00+02:00, not 18:00+00:00.
+        var original = new DateTimeOffset(2026, 6, 15, 20, 0, 0, TimeSpan.FromHours(2));
+
+        var sizePos = writer.BeginDocument();
+        writer.WriteDateTimeOffset("timestamp", original);
+        writer.EndDocument(sizePos);
+
+        var documentBytes = buffer[..writer.Position];
+        var reader = new BsonSpanReader(documentBytes, _keys);
+
+        reader.ReadDocumentSize();
+        var type = reader.ReadBsonType();
+        reader.ReadElementHeader();
+
+        // The wire tag is BsonType.DateTimeOffset - a value written by WriteDateTimeOffset never
+        // uses the plain BsonType.DateTime tag, so a reader can always tell whether the offset was
+        // actually preserved on write, without knowing the C# property type in advance.
+        Assert.Equal(BsonType.DateTimeOffset, type);
+
+        var readBack = reader.ReadDateTimeOffset(type);
+
+        // Both the instant and the original offset must survive the round-trip.
+        Assert.Equal(original.ToUniversalTime(), readBack.ToUniversalTime());
+        Assert.Equal(original.Offset, readBack.Offset);
+        Assert.Equal(original, readBack);
+    }
+
+    [Fact]
+    public void ReadDateTimeOffset_LegacyDateTimeTag_StillDecodesAsOffsetZero()
+    {
+        // Back-compat characterisation: a DateTimeOffset field written before BsonType.DateTimeOffset
+        // existed is on disk under the plain BsonType.DateTime tag (8 bytes, no offset - the offset
+        // was already lost forever at write time, not something a reader can recover). Reading that
+        // legacy tag through the new ReadDateTimeOffset(BsonType) overload must decode it exactly as
+        // it always has - Offset=0 - rather than misreading it as the new 10-byte layout.
+        Span<byte> buffer = stackalloc byte[256];
+        var writer = new BsonSpanWriter(buffer, _keyMap);
+
+        var legacyUtc = new DateTime(2026, 6, 15, 18, 0, 0, DateTimeKind.Utc);
+
+        var sizePos = writer.BeginDocument();
+        writer.WriteDateTime("timestamp", legacyUtc);
+        writer.EndDocument(sizePos);
+
+        var documentBytes = buffer[..writer.Position];
+        var reader = new BsonSpanReader(documentBytes, _keys);
+
+        reader.ReadDocumentSize();
+        var type = reader.ReadBsonType();
+        reader.ReadElementHeader();
+
+        Assert.Equal(BsonType.DateTime, type);
+
+        var readBack = reader.ReadDateTimeOffset(type);
+
+        Assert.Equal(legacyUtc, readBack.UtcDateTime);
+        Assert.Equal(TimeSpan.Zero, readBack.Offset);
+    }
+
+    [Fact]
     public void WriteAndRead_NumericTypes()
     {
         Span<byte> buffer = stackalloc byte[256];

--- a/tests/BLite.Tests/BsonValueTests.cs
+++ b/tests/BLite.Tests/BsonValueTests.cs
@@ -202,7 +202,7 @@ public class BsonValueTests
     {
         var dto = new DateTimeOffset(2025, 6, 15, 8, 30, 0, TimeSpan.Zero);
         var v = BsonValue.FromDateTimeOffset(dto);
-        Assert.Equal(BsonType.DateTime, v.Type);
+        Assert.Equal(BsonType.DateTimeOffset, v.Type);
         Assert.Equal(dto, v.AsDateTimeOffset);
     }
 


### PR DESCRIPTION
## Summary

- `DateTimeOffset` values now round-trip with their original offset instead of being silently normalised to UTC (`Offset=0`) on read. Root cause and repro are in #140.
- Adds a distinct `BsonType.DateTimeOffset` wire tag (`0x14`, unassigned by the BSON spec) with a 10-byte layout: the existing 8-byte UTC millisecond timestamp + a 2-byte signed offset-in-minutes trailer.
- Every place that branched on `BsonType.DateTime` for a value that could be a `DateTimeOffset` (skip-length, `BsonValue` accessors/equality/comparison, BLQL predicate/index-key building, projection, expression evaluation, schema generation, source-generated entity readers) gets a matching `BsonType.DateTimeOffset` arm. Index/sort ordering is deliberately still keyed by instant, not offset - only how the value displays/reads back changes.

## Backward compatibility

A `DateTimeOffset` field written before this change is on disk tagged plain `BsonType.DateTime` (offset already lost at write time - not something a reader can recover). Reading that legacy tag keeps decoding it exactly as it always has (`Offset=0`, no crash, no behavior change). Only values written *after* this fix, through the new `WriteDateTimeOffset`, get tagged `BsonType.DateTimeOffset` and gain a correctly round-tripped offset. Old and new-tagged documents can coexist in the same collection - `BsonValueComparer` compares them by instant across both tags so range scans keep working during the transition.

The generated entity (de)serializers pick this up automatically: `ReadDateTimeOffset` was added to the source generator's "coerced" read set, so it already passes the wire-read `BsonType` into the new `ReadDateTimeOffset(BsonType)` overload - no regeneration-breaking API change, existing calls to the parameterless `ReadDateTimeOffset()` keep their current (legacy, `Offset=0`) behavior.

## Testing

- `BsonSpanReaderWriterTests.WriteAndRead_DateTimeOffset_PreservesOffset` - new type tag round-trips both instant and offset.
- `BsonSpanReaderWriterTests.ReadDateTimeOffset_LegacyDateTimeTag_StillDecodesAsOffsetZero` - back-compat characterisation: reading a value written under the old plain `BsonType.DateTime` tag still decodes as `Offset=0`, unchanged.
- `BsonValueTests.FromDateTimeOffset_RoundTrips_ThroughUnixMs` updated: `BsonValue.FromDateTimeOffset(...).Type` is now `BsonType.DateTimeOffset`, not `BsonType.DateTime` (its previous assertion only happened to pass because the test used a zero offset, which is exactly why this went unnoticed).
- Full suite: 2299 passed, 4 skipped (pre-existing, unrelated to this change), 0 failed. The 3 `MultiProcessWalSharedMemoryTests` failures tracked separately in #134 are unaffected by this change - reproduced identically on `main` before this branch.

Fixes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
