### PR TITLE
fix(query): fall back to full scan for computed properties in predicates

### DIFF
--- a/src/BLite.Core/Query/BsonExpressionEvaluator.cs
+++ b/src/BLite.Core/Query/BsonExpressionEvaluator.cs
@@ -123,7 +123,8 @@ internal static class BsonExpressionEvaluator
         // ── Bare bool member: e => e.IsActive  →  IsActive == true ──────────────
         if (body is MemberExpression bareM &&
             bareM.Expression == parameter &&
-            bareM.Type == typeof(bool))
+            bareM.Type == typeof(bool) &&
+            IsPersistedMember(bareM.Member))
         {
             var bsonName = bareM.Member.Name.ToLowerInvariant();
             if (bsonName == "id") bsonName = "_id";
@@ -134,7 +135,8 @@ internal static class BsonExpressionEvaluator
         if (body is MemberExpression { Member.Name: "HasValue" } hasValueExpr &&
             hasValueExpr.Expression is MemberExpression innerHasValueMember &&
             innerHasValueMember.Expression == parameter &&
-            Nullable.GetUnderlyingType(innerHasValueMember.Type) != null)
+            Nullable.GetUnderlyingType(innerHasValueMember.Type) != null &&
+            IsPersistedMember(innerHasValueMember.Member))
         {
             var bsonName = innerHasValueMember.Member.Name.ToLowerInvariant();
             if (bsonName == "id") bsonName = "_id";
@@ -147,7 +149,8 @@ internal static class BsonExpressionEvaluator
             // Fast path: !e.BoolProp → BoolProp == false
             if (notExpr.Operand is MemberExpression notM &&
                 notM.Expression == parameter &&
-                notM.Type == typeof(bool))
+                notM.Type == typeof(bool) &&
+                IsPersistedMember(notM.Member))
             {
                 var bsonName = notM.Member.Name.ToLowerInvariant();
                 if (bsonName == "id") bsonName = "_id";
@@ -167,7 +170,8 @@ internal static class BsonExpressionEvaluator
             if (mc.Method.Name == "Equals" &&
                 mc.Arguments.Count == 1 &&
                 mc.Object is MemberExpression equalsOnMember &&
-                equalsOnMember.Expression == parameter)
+                equalsOnMember.Expression == parameter &&
+                IsPersistedMember(equalsOnMember.Member))
             {
                 var fieldName   = equalsOnMember.Member.Name;
                 var bsonName    = fieldName.ToLowerInvariant();
@@ -191,7 +195,8 @@ internal static class BsonExpressionEvaluator
                 strMember.Expression == parameter &&
                 strMember.Type == typeof(string) &&
                 mc.Arguments.Count == 1 &&
-                mc.Method.Name is "Contains" or "StartsWith" or "EndsWith")
+                mc.Method.Name is "Contains" or "StartsWith" or "EndsWith" &&
+                IsPersistedMember(strMember.Member))
             {
                 var bsonName = strMember.Member.Name.ToLowerInvariant();
                 if (bsonName == "id") bsonName = "_id";
@@ -210,7 +215,8 @@ internal static class BsonExpressionEvaluator
                 mc.Arguments.Count == 1 &&
                 mc.Arguments[0] is MemberExpression staticStrMember &&
                 staticStrMember.Expression == parameter &&
-                staticStrMember.Type == typeof(string))
+                staticStrMember.Type == typeof(string) &&
+                IsPersistedMember(staticStrMember.Member))
             {
                 var bsonName = staticStrMember.Member.Name.ToLowerInvariant();
                 if (bsonName == "id") bsonName = "_id";
@@ -227,7 +233,8 @@ internal static class BsonExpressionEvaluator
                 {
                     var argUnwrapped = UnwrapConvert(mc.Arguments[0]);
                     if (argUnwrapped is MemberExpression inMember &&
-                        inMember.Expression == parameter)
+                        inMember.Expression == parameter &&
+                        IsPersistedMember(inMember.Member))
                     {
                         var (ok, collection) = TryEvaluate(mc.Object);
                         if (ok && collection != null)
@@ -242,7 +249,8 @@ internal static class BsonExpressionEvaluator
                 {
                     var argUnwrapped = UnwrapConvert(mc.Arguments[1]);
                     if (argUnwrapped is MemberExpression enumInMember &&
-                        enumInMember.Expression == parameter)
+                        enumInMember.Expression == parameter &&
+                        IsPersistedMember(enumInMember.Member))
                     {
                         var (ok, collection) = TryEvaluateCollection(mc.Arguments[0]);
                         if (ok && collection != null)
@@ -288,7 +296,7 @@ internal static class BsonExpressionEvaluator
                 nodeType = Flip(nodeType);
             }
 
-            if (leftInner is MemberExpression member && member.Expression == parameter)
+            if (leftInner is MemberExpression member && member.Expression == parameter && IsPersistedMember(member.Member))
             {
                 var fieldName = member.Member.Name;
                 var bsonName  = fieldName.ToLowerInvariant();
@@ -340,6 +348,8 @@ internal static class BsonExpressionEvaluator
         // The instance on which CompareTo is called: unwrap Convert / Nullable.Value
         var instanceExpr = UnwrapNullableValue(UnwrapConvert(ctMc.Object!));
         if (instanceExpr is not MemberExpression ctMember || ctMember.Expression != parameter)
+            return null;
+        if (!IsPersistedMember(ctMember.Member))
             return null;
 
         var fieldName = ctMember.Member.Name;
@@ -689,6 +699,16 @@ internal static class BsonExpressionEvaluator
 
     private static bool IsDirectParameterAccess(Expression expr, ParameterExpression p)
         => expr is MemberExpression m && m.Expression == p;
+
+    /// <summary>
+    /// True for a field, or a property with a setter - the shapes BLite's document mapper actually
+    /// persists as a BSON field. A get-only property (<c>public bool IsOpen => State != Closed</c>) has
+    /// no backing BSON field at all, so pushing it down into <see cref="CreatePredicate"/> would scan
+    /// every document for a field name that can never exist and silently return <c>false</c> for
+    /// everyone - wrong, instead of falling back to a real in-memory evaluation of the getter.
+    /// </summary>
+    private static bool IsPersistedMember(MemberInfo member)
+        => member is not PropertyInfo { CanWrite: false };
 
     /// <summary>
     /// Unwraps a single <c>Convert</c> / <c>ConvertChecked</c> node if present.


### PR DESCRIPTION
## Summary
- Fixes #143: predicates touching a get-only computed property (e.g. `IsOpen => State != Closed`) were pushed down into a BSON field lookup by property name, silently returning `false` for every document since no such field is ever stored.
- Added `IsPersistedMember` (a member is only pushed down if it's a field or a property with a setter) and gated every member-name extraction point in `BsonExpressionEvaluator` on it: bare bool member, `Nullable.HasValue`, logical NOT, `.Equals()`, string instance methods, static string helpers, the IN operator (both `list.Contains(x.Prop)` and `Enumerable.Contains(list, x.Prop)`), the general binary comparison path, and `CompareTo`.
- When a member fails the check, `TryCompileBody` returns `null`, so `DocumentCollection.FetchAsync` falls through to its existing full-scan + in-memory-filter strategy, which compiles the real expression tree and evaluates the actual getter correctly - matching plain LINQ-to-Objects semantics instead of silently returning wrong results.

## Test plan
- [ ] Unit test: entity with a get-only bool property derived from a stored enum field; insert with the property `true`, assert `FindAsync(x => x.ComputedProp)` returns it (currently returns empty without the fix)
- [ ] Regression: existing tests for the still-covered patterns (bare bool on a real stored bool field, `!x.Prop`, string methods, IN, binary comparisons, `CompareTo`) continue to push down correctly
- [ ] `dotnet build`/`dotnet test` on `BLite.Core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)